### PR TITLE
Update network-wrapper

### DIFF
--- a/network-wrapper
+++ b/network-wrapper
@@ -232,7 +232,9 @@ then
      if [ $DHCP_CLIENT = "dhclient"  ]
     then
         SHORTGUESTNAME=${GUESTNAME:0:12}
-        ip netns exec $NSPID $DHCP_CLIENT -pf "/var/run/dhclient-docker.$SHORTGUESTNAME.pid" -H $SHORTGUESTNAME $CONTAINER_IFNAME
+        # Removing -H option dependency, as this option is not supported in ubuntu. 
+        # in Centos/RHEL, this is an optional and not required. 
+        ip netns exec $NSPID $DHCP_CLIENT -pf "/var/run/dhclient-docker.$SHORTGUESTNAME.pid" $CONTAINER_IFNAME
     fi
 else
     echo "only udhcpc / dhclient currently supported"


### PR DESCRIPTION
The option is not supported in Ubuntu Host and is not required in Centos
and RHEL.